### PR TITLE
Release 1.0.1

### DIFF
--- a/src/TeaTime.Slack/Controllers/OAuthCallbackController.cs
+++ b/src/TeaTime.Slack/Controllers/OAuthCallbackController.cs
@@ -66,6 +66,7 @@
 
                     var fields = new List<HashEntry>
                     {
+                        new HashEntry("team_name", response.TeamName),
                         new HashEntry("access_token", response.AccessToken),
                         new HashEntry("install_time", DateTime.UtcNow.ToString("O"))
                     };

--- a/src/TeaTime/TeaTime.csproj
+++ b/src/TeaTime/TeaTime.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>7.1</LangVersion>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="6.0.0" />


### PR DESCRIPTION
- Store the team name on install
> This helps with diagnosing support issues because we can lookup the team name to get the correct slack ids