### PR TITLE
Added global stats to the home page

### DIFF
--- a/src/TeaTime.Common/Abstractions/Data/IStatisticsRepository.cs
+++ b/src/TeaTime.Common/Abstractions/Data/IStatisticsRepository.cs
@@ -1,0 +1,19 @@
+﻿namespace TeaTime.Common.Abstractions.Data
+{
+    using System.Threading.Tasks;
+
+    public interface IStatisticsRepository
+    {
+        /// <summary>
+        /// Gets the count of all orders made from ended runs
+        /// </summary>
+        /// <returns></returns>
+        Task<long> CountGlobalOrdersMadeAsync();
+
+        /// <summary>
+        /// Gets the count of all runs which have ended
+        /// </summary>
+        /// <returns></returns>
+        Task<long> CountGlobalEndedRunsAsync();
+    }
+}

--- a/src/TeaTime.Common/Features/Statistics/Models/GlobalTotals.cs
+++ b/src/TeaTime.Common/Features/Statistics/Models/GlobalTotals.cs
@@ -1,0 +1,8 @@
+﻿namespace TeaTime.Common.Features.Statistics.Models
+{
+    public class GlobalTotals
+    {
+        public long OrdersMade { get; set; }
+        public long RunsEnded { get; set; }
+    }
+}

--- a/src/TeaTime.Common/Features/Statistics/Queries/GetGlobalTotalsQuery.cs
+++ b/src/TeaTime.Common/Features/Statistics/Queries/GetGlobalTotalsQuery.cs
@@ -1,0 +1,9 @@
+﻿namespace TeaTime.Common.Features.Statistics.Queries
+{
+    using Abstractions;
+    using Models;
+
+    public class GetGlobalTotalsQuery : IQuery<GlobalTotals>
+    {
+    }
+}

--- a/src/TeaTime.Common/Features/Statistics/StatisticsQueryHandler.cs
+++ b/src/TeaTime.Common/Features/Statistics/StatisticsQueryHandler.cs
@@ -1,0 +1,31 @@
+﻿namespace TeaTime.Common.Features.Statistics
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Abstractions.Data;
+    using MediatR;
+    using Models;
+    using Queries;
+
+    public class StatisticsQueryHandler : IRequestHandler<GetGlobalTotalsQuery, GlobalTotals>
+    {
+        private readonly IStatisticsRepository _statisticsRepository;
+
+        public StatisticsQueryHandler(IStatisticsRepository statisticsRepository)
+        {
+            _statisticsRepository = statisticsRepository;
+        }
+
+        public async Task<GlobalTotals> Handle(GetGlobalTotalsQuery request, CancellationToken cancellationToken)
+        {
+            var ordersTask = _statisticsRepository.CountGlobalOrdersMadeAsync();
+            var runsTask = _statisticsRepository.CountGlobalEndedRunsAsync();
+
+            return new GlobalTotals
+            {
+                OrdersMade = await ordersTask,
+                RunsEnded = await runsTask
+            };
+        }
+    }
+}

--- a/src/TeaTime.Data.MySql/Repositories/StatisticsRepository.cs
+++ b/src/TeaTime.Data.MySql/Repositories/StatisticsRepository.cs
@@ -1,0 +1,26 @@
+﻿namespace TeaTime.Data.MySql.Repositories
+{
+    using System.Threading.Tasks;
+    using Common.Abstractions.Data;
+
+    public class StatisticsRepository : BaseRepository, IStatisticsRepository
+    {
+        public StatisticsRepository(IMySqlConnectionFactory factory) : base(factory)
+        {
+        }
+
+        public Task<long> CountGlobalOrdersMadeAsync()
+        {
+            const string sql = "SELECT count(*) FROM orders o JOIN runs r ON r.id = o.runId WHERE r.ended = 1";
+
+            return SingleOrDefaultAsync<long>(sql);
+        }
+
+        public Task<long> CountGlobalEndedRunsAsync()
+        {
+            const string sql = "SELECT count(*) FROM runs WHERE ended = 1";
+
+            return SingleOrDefaultAsync<long>(sql);
+        }
+    }
+}

--- a/src/TeaTime.Data.MySql/ServiceCollectionExtensions.cs
+++ b/src/TeaTime.Data.MySql/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@
             services.AddSingleton<IOptionsRepository, OptionsRepository>();
             services.AddSingleton<ILockRepository, LockRepository>();
             services.AddSingleton<IIllMakeRepository, IllMakeRepository>();
+            services.AddSingleton<IStatisticsRepository, StatisticsRepository>();
 
             services.AddSingleton<IIdGenerator<long>, MySqlIdGenerator>();
             services.AddSingleton<IDistributedHash, MySqlDistributedHash>();

--- a/src/TeaTime/Controllers/HomeController.cs
+++ b/src/TeaTime/Controllers/HomeController.cs
@@ -1,14 +1,32 @@
 ﻿namespace TeaTime.Controllers
 {
+    using System.Threading.Tasks;
+    using Common.Features.Statistics.Queries;
+    using MediatR;
     using Microsoft.AspNetCore.Mvc;
     using ViewModels;
 
     public class HomeController : Controller
     {
-        [Route("")]
-        public IActionResult Index()
+        private readonly IMediator _mediator;
+
+        public HomeController(IMediator mediator)
         {
-            return View();
+            _mediator = mediator;
+        }
+
+        [Route("")]
+        public async Task<IActionResult> Index()
+        {
+            var totals = await _mediator.Send(new GetGlobalTotalsQuery());
+
+            var viewModel = new IndexViewModel
+            {
+                TotalOrdersMade = totals.OrdersMade,
+                TotalEndedRuns = totals.RunsEnded
+            };
+
+            return View(viewModel);
         }
 
         [Route("privacy")]

--- a/src/TeaTime/ViewModels/IndexViewModel.cs
+++ b/src/TeaTime/ViewModels/IndexViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace TeaTime.ViewModels
+{
+    public class IndexViewModel
+    {
+        public long TotalOrdersMade { get; set; }
+        public long TotalEndedRuns { get; set; }
+    }
+}

--- a/src/TeaTime/Views/Home/Index.cshtml
+++ b/src/TeaTime/Views/Home/Index.cshtml
@@ -1,7 +1,28 @@
-﻿@{
+﻿@model TeaTime.ViewModels.IndexViewModel
+
+@{
     Layout = "_PageLayout";
 }
 
 <section class="section has-text-centered">
     <partial name="_Slack" />
+</section>
+
+<section class="section has-text-centered">
+    <div class="container">
+        <div class="columns is-centered">
+            <div class="column is-one-fifth">
+                <div class="notification is-primary has-text-centered">
+                    <p class="title">@Model.TotalOrdersMade</p>
+                    <p class="subtitle is-6">Thirsts quenched</p>
+                </div>
+            </div>
+            <div class="column is-one-fifth">
+                <div class="notification is-primary has-text-centered">
+                    <p class="title">@Model.TotalEndedRuns</p>
+                    <p class="subtitle is-6">Rounds lost</p>
+                </div>
+            </div>
+        </div>
+    </div>
 </section>


### PR DESCRIPTION
Added global stats to the home page

- "Thirsts quenched" = totals orders made from ended runs
- "Rounds lost" = total number of ended runs

![image](https://user-images.githubusercontent.com/709976/77838024-8efd2800-71bb-11ea-8093-df09ff977df3.png)

These are not currently cached, however #30 should solve that
