### PR TITLE
More nullable fixes

### DIFF
--- a/src/TeaTime.Common/Collections/HashEntry.cs
+++ b/src/TeaTime.Common/Collections/HashEntry.cs
@@ -14,9 +14,9 @@
         }
 
         public static implicit operator HashEntry(KeyValuePair<string, string> keyValuePair) =>
-            new HashEntry(keyValuePair.Key, keyValuePair.Value);
+            new(keyValuePair.Key, keyValuePair.Value);
 
         public static implicit operator KeyValuePair<string, string>(HashEntry hashEntry) =>
-            new KeyValuePair<string, string>(hashEntry.Field, hashEntry.Value);
+            new(hashEntry.Field, hashEntry.Value);
     }
 }

--- a/src/TeaTime.Slack/Controllers/OAuthCallbackController.cs
+++ b/src/TeaTime.Slack/Controllers/OAuthCallbackController.cs
@@ -69,7 +69,7 @@
                 // Validate the response to make sure we have all the data
                 if (!response.ValidateProperties())
                 {
-                    _logger.LogWarning("Response is missing data {@Response}", response);
+                    _logger.LogWarning("Response is missing data {@Response}", response.ToLogObject());
                     return View(OAuthCallbackViewModel.Error("installation_error"));
                 }
 
@@ -90,7 +90,7 @@
                     if (string.IsNullOrWhiteSpace(incomingWebhook.ChannelId) ||
                         string.IsNullOrWhiteSpace(incomingWebhook.Url))
                     {
-                        _logger.LogWarning("Incomming WebHook is missing data");
+                        _logger.LogWarning("Incoming WebHook is missing data");
                     }
                     else
                     {

--- a/src/TeaTime.Slack/Controllers/OAuthCallbackController.cs
+++ b/src/TeaTime.Slack/Controllers/OAuthCallbackController.cs
@@ -43,11 +43,8 @@
             if (options == null || !options.IsValid())
             {
                 _logger.LogWarning("Ignoring OAuth callback. No OAuth settings set");
-
                 return View(OAuthCallbackViewModel.Error("not_configured"));
             }
-
-            var errorCode = "unknown";
 
             try
             {
@@ -60,41 +57,57 @@
                     Code = code
                 });
 
-                if (response.IsSuccess)
+                // Check response is successful or not (according to slack)
+                if (!response.IsSuccess)
                 {
-                    _logger.LogInformation("TeaTime installed in team {TeamId} ({TeamName}) with scope {Scope}",
-                        response.TeamId, response.TeamName, response.Scope);
+                    _logger.LogError("Failed to install into slack channel. Error: {ErrorCode}", response.Error);
 
-                    var fields = new List<HashEntry>
-                    {
-                        new("team_name", response.TeamName),
-                        new("access_token", response.AccessToken),
-                        new("install_time", DateTime.UtcNow.ToString("O"))
-                    };
-
-                    // Add config for webhook if available
-                    if (response.IncomingWebhook != null)
-                    {
-                        fields.Add(new HashEntry($"webhook:{response.IncomingWebhook.ChannelId}:url",
-                            response.IncomingWebhook.Url));
-                    }
-
-                    await _hash.SetAsync("slack:" + response.TeamId, fields);
-
-                    return View(OAuthCallbackViewModel.Ok(response.TeamName));
+                    // set the error code for the view
+                    return View(OAuthCallbackViewModel.Error("slack:" + response.Error));
                 }
 
-                _logger.LogError("Failed to install into slack channel. Error: {ErrorCode}", response.Error);
+                // Validate the response to make sure we have all the data
+                if (!response.ValidateProperties())
+                {
+                    _logger.LogWarning("Response is missing data {@Response}", response);
+                    return View(OAuthCallbackViewModel.Error("installation_error"));
+                }
 
-                // set the error code for the view
-                errorCode = "slack:" + response.Error;
+                _logger.LogInformation("TeaTime installed in team {TeamId} ({TeamName}) with scope {Scope}",
+                    response.TeamId, response.TeamName, response.Scope);
+
+                var fields = new List<HashEntry>
+                {
+                    new("team_name", response.TeamName),
+                    new("access_token", response.AccessToken),
+                    new("install_time", DateTime.UtcNow.ToString("O"))
+                };
+
+                // Add config for webhook if available
+                var incomingWebhook = response.IncomingWebhook;
+                if (incomingWebhook != null)
+                {
+                    if (string.IsNullOrWhiteSpace(incomingWebhook.ChannelId) ||
+                        string.IsNullOrWhiteSpace(incomingWebhook.Url))
+                    {
+                        _logger.LogWarning("Incomming WebHook is missing data");
+                    }
+                    else
+                    {
+
+                        fields.Add(new HashEntry($"webhook:{incomingWebhook.ChannelId}:url", incomingWebhook.Url));
+                    }
+                }
+
+                await _hash.SetAsync("slack:" + response.TeamId, fields);
+
+                return View(OAuthCallbackViewModel.Ok(response.TeamName));
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to get OAuth token");
+                return View(OAuthCallbackViewModel.Error("unknown"));
             }
-
-            return View(OAuthCallbackViewModel.Error(errorCode));
         }
     }
 }

--- a/src/TeaTime.Slack/Controllers/SlackController.cs
+++ b/src/TeaTime.Slack/Controllers/SlackController.cs
@@ -44,9 +44,9 @@ namespace TeaTime.Slack.Controllers
                 return Ok(ErrorStrings.General(), ResponseType.User);
             }
 
-            if (string.IsNullOrWhiteSpace(slashCommand.Command))
+            if (string.IsNullOrWhiteSpace(slashCommand.Text))
             {
-                _logger.LogError("Slash command contains no command");
+                _logger.LogError("Slash command contains no text");
                 return Ok(ErrorStrings.General(), ResponseType.User);
             }
 

--- a/src/TeaTime.Slack/Models/Action.cs
+++ b/src/TeaTime.Slack/Models/Action.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models
+﻿#nullable disable
+namespace TeaTime.Slack.Models
 {
     public abstract class Action
     {

--- a/src/TeaTime.Slack/Models/Attachment.cs
+++ b/src/TeaTime.Slack/Models/Attachment.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models
+﻿#nullable disable
+namespace TeaTime.Slack.Models
 {
     using System.Collections.Generic;
     using System.Text.Json.Serialization;

--- a/src/TeaTime.Slack/Models/CallbackData.cs
+++ b/src/TeaTime.Slack/Models/CallbackData.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models
+﻿#nullable disable
+namespace TeaTime.Slack.Models
 {
     internal class CallbackData
     {

--- a/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageAction.cs
+++ b/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageAction.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models.Requests.InteractiveMessages
+﻿#nullable disable
+namespace TeaTime.Slack.Models.Requests.InteractiveMessages
 {
     public class MessageAction
     {

--- a/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageChannel.cs
+++ b/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageChannel.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models.Requests.InteractiveMessages
+﻿#nullable disable
+namespace TeaTime.Slack.Models.Requests.InteractiveMessages
 {
     public class MessageChannel
     {

--- a/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageRequest.cs
+++ b/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageRequest.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models.Requests.InteractiveMessages
+﻿#nullable disable
+namespace TeaTime.Slack.Models.Requests.InteractiveMessages
 {
     using Microsoft.AspNetCore.Mvc;
 

--- a/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageRequestPayload.cs
+++ b/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageRequestPayload.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models.Requests.InteractiveMessages
+﻿#nullable disable
+namespace TeaTime.Slack.Models.Requests.InteractiveMessages
 {
     using System.Collections.Generic;
     using System.Text.Json.Serialization;

--- a/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageTeam.cs
+++ b/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageTeam.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models.Requests.InteractiveMessages
+﻿#nullable disable
+namespace TeaTime.Slack.Models.Requests.InteractiveMessages
 {
     public class MessageTeam
     {

--- a/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageUser.cs
+++ b/src/TeaTime.Slack/Models/Requests/InteractiveMessages/MessageUser.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models.Requests.InteractiveMessages
+﻿#nullable disable
+namespace TeaTime.Slack.Models.Requests.InteractiveMessages
 {
     public class MessageUser
     {

--- a/src/TeaTime.Slack/Models/Requests/OAuthTokenRequest.cs
+++ b/src/TeaTime.Slack/Models/Requests/OAuthTokenRequest.cs
@@ -1,4 +1,5 @@
-﻿namespace TeaTime.Slack.Models.Requests
+﻿#nullable disable
+namespace TeaTime.Slack.Models.Requests
 {
     public class OAuthTokenRequest
     {

--- a/src/TeaTime.Slack/Models/Requests/SlashCommand.cs
+++ b/src/TeaTime.Slack/Models/Requests/SlashCommand.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace TeaTime.Slack.Models.Requests
 {
     using Microsoft.AspNetCore.Mvc;

--- a/src/TeaTime.Slack/Models/Responses/BaseResponse.cs
+++ b/src/TeaTime.Slack/Models/Responses/BaseResponse.cs
@@ -1,10 +1,9 @@
-﻿namespace TeaTime.Slack.Models.Responses
-{
-    public abstract class BaseResponse
-    {
-        public bool Ok { get; set; }
-        public string? Error { get; set; }
+﻿namespace TeaTime.Slack.Models.Responses;
 
-        public bool IsSuccess => Ok;
-    }
+public abstract class BaseResponse
+{
+    public bool Ok { get; set; }
+    public string? Error { get; set; }
+
+    public bool IsSuccess => Ok;
 }

--- a/src/TeaTime.Slack/Models/Responses/OAuthTokenResponse.cs
+++ b/src/TeaTime.Slack/Models/Responses/OAuthTokenResponse.cs
@@ -31,4 +31,17 @@ public class OAuthTokenResponse : BaseResponse
                !string.IsNullOrWhiteSpace(TeamName) &&
                !string.IsNullOrWhiteSpace(TeamId);
     }
+
+    public object ToLogObject()
+    {
+        return new
+        {
+            AccessToken = Redact(AccessToken),
+            Scope,
+            TeamName = Redact(TeamName),
+            TeamId
+        };
+
+        static string? Redact(string? value) => string.IsNullOrWhiteSpace(value) ? value : "***";
+    }
 }

--- a/src/TeaTime.Slack/Models/Responses/OAuthTokenResponse.cs
+++ b/src/TeaTime.Slack/Models/Responses/OAuthTokenResponse.cs
@@ -1,22 +1,34 @@
-﻿namespace TeaTime.Slack.Models.Responses
+﻿namespace TeaTime.Slack.Models.Responses;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+public class OAuthTokenResponse : BaseResponse
 {
-    using System.Text.Json.Serialization;
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; set; }
 
-    public class OAuthTokenResponse : BaseResponse
+    [JsonPropertyName("scope")]
+    public string? Scope { get; set; }
+
+    [JsonPropertyName("team_name")]
+    public string? TeamName { get; set; }
+
+    [JsonPropertyName("team_id")]
+    public string? TeamId { get; set; }
+
+    [JsonPropertyName("incoming_webhook")]
+    public OAuthTokenResponseIncomingWebhook? IncomingWebhook { get; set; }
+
+    [MemberNotNullWhen(true, nameof(AccessToken))]
+    [MemberNotNullWhen(true, nameof(Scope))]
+    [MemberNotNullWhen(true, nameof(TeamName))]
+    [MemberNotNullWhen(true, nameof(TeamId))]
+    public bool ValidateProperties()
     {
-        [JsonPropertyName("access_token")]
-        public string AccessToken { get; set; }
-
-        [JsonPropertyName("scope")]
-        public string Scope { get; set; }
-
-        [JsonPropertyName("team_name")]
-        public string TeamName { get; set; }
-
-        [JsonPropertyName("team_id")]
-        public string TeamId { get; set; }
-
-        [JsonPropertyName("incoming_webhook")]
-        public OAuthTokenResponseIncomingWebhook? IncomingWebhook { get; set; }
+        return !string.IsNullOrWhiteSpace(AccessToken) &&
+               !string.IsNullOrWhiteSpace(Scope) &&
+               !string.IsNullOrWhiteSpace(TeamName) &&
+               !string.IsNullOrWhiteSpace(TeamId);
     }
 }

--- a/src/TeaTime.Slack/Models/Responses/OAuthTokenResponseIncomingWebhook.cs
+++ b/src/TeaTime.Slack/Models/Responses/OAuthTokenResponseIncomingWebhook.cs
@@ -1,19 +1,18 @@
-﻿namespace TeaTime.Slack.Models.Responses
+﻿namespace TeaTime.Slack.Models.Responses;
+
+using System.Text.Json.Serialization;
+
+public class OAuthTokenResponseIncomingWebhook
 {
-    using System.Text.Json.Serialization;
+    [JsonPropertyName("channel")]
+    public string? Channel { get; set; }
 
-    public class OAuthTokenResponseIncomingWebhook
-    {
-        [JsonPropertyName("channel")]
-        public string Channel { get; set; }
+    [JsonPropertyName("channel_id")]
+    public string? ChannelId { get; set; }
 
-        [JsonPropertyName("channel_id")]
-        public string ChannelId { get; set; }
+    [JsonPropertyName("configuration_url")]
+    public string? ConfigurationUrl { get; set; }
 
-        [JsonPropertyName("configuration_url")]
-        public string ConfigurationUrl { get; set; }
-
-        [JsonPropertyName("url")]
-        public string Url { get; set; }
-    }
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
 }

--- a/src/TeaTime.Slack/Models/Responses/SlashCommandResponse.cs
+++ b/src/TeaTime.Slack/Models/Responses/SlashCommandResponse.cs
@@ -1,50 +1,42 @@
-﻿namespace TeaTime.Slack.Models.Responses
+﻿namespace TeaTime.Slack.Models.Responses;
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+public class SlashCommandResponse(string? text, ResponseType responseType)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text.Json.Serialization;
-
-    public class SlashCommandResponse
+    public SlashCommandResponse() : this(null, Responses.ResponseType.Channel)
     {
-        public SlashCommandResponse()
+    }
+
+    public string? Text { get; set; } = text;
+
+    [JsonPropertyName("replace_original")]
+    public bool ReplaceOriginal { get; set; }
+
+    [JsonIgnore]
+    public ResponseType Type { get; set; } = responseType;
+
+    public IEnumerable<Attachment>? Attachments { get; set; }
+
+    [JsonPropertyName("response_type")]
+    public string ResponseType
+    {
+        get
         {
-            Type = Responses.ResponseType.Channel;
-        }
-
-        public SlashCommandResponse(string? text, ResponseType responseType)
-        {
-            Type = responseType;
-            Text = text;
-        }
-
-        public string? Text { get; set; }
-
-        [JsonPropertyName("replace_original")]
-        public bool ReplaceOriginal { get; set; }
-
-        [JsonIgnore]
-        public ResponseType Type { get; set; }
-
-        public IEnumerable<Attachment>? Attachments { get; set; }
-
-        [JsonPropertyName("response_type")]
-        public string ResponseType
-        {
-            get
+            return Type switch
             {
-                return Type switch
-                {
-                    Responses.ResponseType.Channel => "in_channel",
-                    Responses.ResponseType.User => "ephemeral",
-                    _ => throw new ArgumentOutOfRangeException()
-                };
-            }
+                Responses.ResponseType.Channel => "in_channel",
+                Responses.ResponseType.User => "ephemeral",
+                _ => throw new ArgumentOutOfRangeException()
+            };
         }
     }
+}
 
-    public enum ResponseType
-    {
-        Channel,
-        User
-    }
+public enum ResponseType
+{
+    Channel,
+    User
 }

--- a/src/TeaTime.Slack/Models/ViewModels/OAuthCallbackViewModel.cs
+++ b/src/TeaTime.Slack/Models/ViewModels/OAuthCallbackViewModel.cs
@@ -1,24 +1,23 @@
-﻿namespace TeaTime.Slack.Models.ViewModels
+﻿namespace TeaTime.Slack.Models.ViewModels;
+
+public class OAuthCallbackViewModel
 {
-    public class OAuthCallbackViewModel
+    public bool Success { get; }
+    public string? TeamName { get; set; }
+    public string? ErrorCode { get; private set; }
+
+    public OAuthCallbackViewModel(bool success)
     {
-        public bool Success { get; }
-        public string? TeamName { get; set; }
-        public string? ErrorCode { get; private set; }
-
-        public OAuthCallbackViewModel(bool success)
-        {
-            Success = success;
-        }
-
-        public static OAuthCallbackViewModel Ok(string teamName) => new OAuthCallbackViewModel(true)
-        {
-            TeamName = teamName
-        };
-
-        public static OAuthCallbackViewModel Error(string errorCode) => new OAuthCallbackViewModel(false)
-        {
-            ErrorCode = errorCode
-        };
+        Success = success;
     }
+
+    public static OAuthCallbackViewModel Ok(string teamName) => new(true)
+    {
+        TeamName = teamName
+    };
+
+    public static OAuthCallbackViewModel Error(string errorCode) => new(false)
+    {
+        ErrorCode = errorCode
+    };
 }


### PR DESCRIPTION
- More nullable fixes for `OAuthCallbackController` and `OAuthTokenResponse`
- Disable nullable on request objects for now to avoid warning spam (will address these later when revisiting the deprecated slack APIs and scopes)
- Fix empty string check for the slash command being on `Command` not `Text`