### PR TITLE
Fix db migration for mariadb

### DIFF
--- a/sql/V0_3_1__Add_soft_delete.sql
+++ b/sql/V0_3_1__Add_soft_delete.sql
@@ -1,11 +1,13 @@
 alter table `options`
     add column deleted boolean default 0,
     add column deletedDate datetime default null,
+    add column activeName VARCHAR(40) AS (IF(deleted = 0, name, NULL)),
     drop index `idx_options_name`,
-    add unique `idx_options_name` (`groupId`, `name`, (IF(deleted,null,1)));
+    add unique `idx_options_name` (`groupId`, `activeName`);
 
 alter table `option_groups`
     add column deleted boolean default 0,
     add column deletedDate datetime default null,
+    add column activeName VARCHAR(40) AS (IF(deleted = 0, name, NULL)),
     drop index `idx_optiongroups_name`,
-    add unique `idx_optiongroups_name` (`roomId`, `name`, (IF(deleted,null,1)));
+    add unique `idx_optiongroups_name` (`roomId`, `activeName`);


### PR DESCRIPTION
The previous unique column logic did not work with MariaDB. This fixes that, however a manual db migration will need to be run:

```sql
alter table `options`
    add column activeName VARCHAR(40) AS (IF(deleted = 0, name, NULL)),
    drop index `idx_options_name`,
    add unique `idx_options_name` (`groupId`, `activeName`);

alter table `option_groups`
    add column activeName VARCHAR(40) AS (IF(deleted = 0, name, NULL)),
    drop index `idx_optiongroups_name`,
    add unique `idx_optiongroups_name` (`roomId`, `activeName`);

update changelog set checksum = 'B130FB98D564C9D9259C8BCCA2EE3603' where version = '0.3.1' and checksum = '97BB94925E73D982EEDE97CEA184FFDA'
```